### PR TITLE
Extract new ons cis variables with databuilder

### DIFF
--- a/analysis/1_combine_wide_data.R
+++ b/analysis/1_combine_wide_data.R
@@ -5,16 +5,20 @@ options(datatable.fread.datatable=FALSE)
 # setwd(dirname(rstudioapi::getActiveDocumentContext()$path))
 # setwd('../')
 
-mh <- fread('output/input_health_mh.csv') %>% 
+mh <- fread('output/input_health_mh.csv') %>%
   select(-contains('visit_date_'))
 
-non_mh <- fread('output/input_health_non_mh.csv') %>% 
+non_mh <- fread('output/input_health_non_mh.csv') %>%
+  select(-contains('visit_date_'))
+
+cis_new <- fread('output/dataset_ons_cis_new.csv') %>%
   select(-contains('visit_date_'))
 
 non_health <- fread('output/input_non_health.csv')
 
 combined <- non_health %>% 
-  left_join(mh, by = 'patient_id') %>% 
-  left_join(non_mh, by = 'patient_id')
+  left_join(mh, by = 'patient_id') %>%
+  left_join(non_mh, by = 'patient_id') %>%
+  left_join(cis_new, by = 'patient_id')
 
 write_csv(combined, 'output/input_cis_wide.csv')

--- a/analysis/2_cis_wide_to_long.R
+++ b/analysis/2_cis_wide_to_long.R
@@ -66,12 +66,24 @@ join_keys <- c('patient_id', 'visit_number')
 
 visit_date <- wide_to_long(cis_wide, 'visit_date', 'visit\\_date\\_\\d+')
 result_mk <- wide_to_long(cis_wide, 'result_mk', 'result\\_mk\\_\\d+')
+
+# new ons cis 
+visit_num  <- wide_to_long(cis_wide, 'visit_num', 'visit\\_num\\_\\d+')
+last_linkage_dt <- wide_to_long(cis_wide, 'last_linkage_dt', 'last\\_linkage\\_dt\\_\\d+')
+is_opted_out_of_nhs_data_share <- wide_to_long(cis_wide, 'is_opted_out_of_nhs_data_share', 'is\\_opted\\_out\\_of\\_nhs\\_data\\_share\\_\\d+')
+
 cis_long <- visit_date %>% 
-  left_join(result_mk, by = join_keys)
-rm(visit_date, result_mk)
+  left_join(result_mk, by = join_keys) %>% 
+  left_join(visit_num, by = join_keys) %>% 
+  left_join(last_linkage_dt, by = join_keys) %>% 
+  left_join(is_opted_out_of_nhs_data_share, by = join_keys)
+
+rm(visit_date, result_mk, visit_num, last_linkage_dt, is_opted_out_of_nhs_data_share)
 cis_wide <- remove_cols_string(cis_wide, 'visit_date')
 cis_wide <- remove_cols_string(cis_wide, 'result_mk')
-
+cis_wide <- remove_cols_string(cis_wide, 'visit_num')
+cis_wide <- remove_cols_string(cis_wide, 'last_linkage_dt')
+cis_wide <- remove_cols_string(cis_wide, 'is_opted_out_of_nhs_data_share')
 
 add_new_wide_col <- function(df_wide, df_long, col, col_regex, join_keys){
   temp <- wide_to_long(df_wide, col, col_regex)

--- a/analysis/9_cumulative_incidence_curves.R
+++ b/analysis/9_cumulative_incidence_curves.R
@@ -11,7 +11,7 @@ prevalence <- fread('output/adjusted_prevalence_group.csv')
 eos_date <- as.IDate('2021-09-30')
 
 # Derive t for outcomes
-derive_t <- function(df){
+derive_t <- function(df, drop_negative = TRUE){
   
   df <- df %>% 
     mutate(min_outcome_date_mh = pmin(cmd_outcome_date, cmd_outcome_date_hospital,
@@ -24,6 +24,10 @@ derive_t <- function(df){
                            end_date - visit_date, 
                            min_outcome_date_mh - visit_date)) %>% 
     select(-min_outcome_date_mh)
+
+    if (drop_negative) {
+    df  <- filter(df, t > 0)  
+    }
   
   return(df)
 }

--- a/analysis/dataset_definition_ons_cis_new.py
+++ b/analysis/dataset_definition_ons_cis_new.py
@@ -1,0 +1,65 @@
+from databuilder.ehrql import Dataset
+from databuilder.tables.beta import tpp as schema
+
+
+#######################################################################################
+# Define study dates 
+#######################################################################################
+
+start_date = '2020-01-24'
+end_date = '2022-03-31'
+n_visits = 26
+
+dataset = Dataset()
+
+#######################################################################################
+# Set population
+# Filter ONS CIS table to visit dates between the study start and end dates (inclusive) 
+# and set the population to only patients who have at least one visit date in study date
+# range
+#######################################################################################
+
+ons_cis = schema.ons_cis.take(schema.ons_cis.visit_date.is_on_or_between(start_date, end_date))
+dataset.set_population(ons_cis.exists_for_patient())
+
+#######################################################################################
+# Define variables
+# Create n_visits sequential variables for the ONS CIS columns of interest
+#######################################################################################
+
+def get_sequential_events(events, num_events, column_name):
+    """
+    This function takes a table of events (multiple per patient), a number of events to be
+    extracted, and a column name to sort by.
+
+    In this case, events is all of the ons_cis table visits that are within the study start
+    and end date.
+    """
+    sort_column = getattr(events, column_name)
+    previous_date = None
+    for _ in range(num_events):
+        # One each iteration through this loop, we first filter the events to only those
+        # LATER than the previous_date found
+        if previous_date is not None:
+            later_events = events.take(sort_column > previous_date)
+        else:
+            later_events = events
+        # Now we sort the events and get the first one
+        next_event = later_events.sort_by(sort_column).first_for_patient()
+        yield next_event
+        # And update previous_date so the next iteration through the loop will filter to
+        # events after this one we've just retrieved 
+        previous_date = getattr(next_event, column_name)
+
+
+# retrieve sequential visits by visit date
+visits = get_sequential_events(ons_cis, n_visits, "visit_date")
+# loop over the visits and for each one, set the variables on the dataset for the columns
+# we're interested in
+# Note that n is zero-indexed, so for n_visits=26, variables will be named
+# e.g. `visit_date_0`, `visit_date_1`, ..., `visit_date_25`
+for n, visit in enumerate(visits):
+    setattr(dataset, f"visit_date_{n}", visit.visit_date)
+    setattr(dataset, f"visit_num_{n}", visit.visit_num)
+    setattr(dataset, f"last_linkage_dt_{n}", visit.last_linkage_dt)
+    setattr(dataset, f"is_opted_out_of_nhs_data_share_{n}", visit.is_opted_out_of_nhs_data_share)

--- a/project.yaml
+++ b/project.yaml
@@ -35,10 +35,21 @@ actions:
         outputs:
             highly_sensitive:
                 cohort: output/input_health_non_mh.csv
-                
+
+    generate_wide_ons_cis_new:
+        run: >
+            databuilder:v0
+                generate-dataset
+                --output output/dataset_ons_cis_new.csv
+                analysis/dataset_definition_ons_cis_new.py
+        outputs:
+            highly_sensitive:
+                dataset: output/dataset_ons_cis_new.csv
+
+
     combine_wide_data:
         run: r:latest analysis/1_combine_wide_data.R
-        needs: [generate_wide_non_health, generate_wide_health_mh, generate_wide_health_non_mh]
+        needs: [generate_wide_non_health, generate_wide_health_mh, generate_wide_health_non_mh, generate_wide_ons_cis_new]
         outputs:
             highly_sensitive:
                 cohort: output/input_cis_wide.csv


### PR DESCRIPTION
This PR add a new dataset definition, `analysis/dataset_definition_ons_cis_new.py` which extracts the new ONS CIS columns not currently available in cohort-extractor, that is:
- `visit_date`
- `visit_num`
- `last_linkage_dt`
- `is_opted_out_of_nhs_data_share`

Note that `is_opted_out_of_nhs_data_share` is returned as a boolean T/F value from the numerical raw data values where 0=opted out and 1=opted in (from database table column `nhs_data_share`).

The variables are extracted and named in the same way as other cohort-extractor study definitions, i.e. 26 sequential variables named with the column name and a number, from 0 - 25, representing the extracted visits in order (i.e. `visit_date_0`, `visit_date_1`, ..., `visit_date_25`).  

In addition to the dataset definition, there are also some minor updates to `project.yaml`, `analysis/1_combine_wide_data.R` and `analysis/2_cis_wide_to_long.R`  to run the new step and include it in the combined data.